### PR TITLE
Use /etc/cfssl instead of /var/pki in entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,7 @@
 set -e
 
 # Generate keys if necessary
-if [ ! -f /var/pki/ca.pem ] || [ ! -f /var/pki/ca-key.pem ] ; then
+if [ ! -f /etc/cfssl/ca.pem ] || [ ! -f /etc/cfssl/ca-key.pem ] ; then
 
     # Create root if no API URI
     if [ ! "${CA_ROOT_URI}" ] ; then


### PR DESCRIPTION
It seems that the container generates new ca certificates on each run because of this script looking for ca files in wrong directory